### PR TITLE
Fix handling of team names in penalties

### DIFF
--- a/code/raw_data_parsers/play_by_play/penalty.py
+++ b/code/raw_data_parsers/play_by_play/penalty.py
@@ -90,9 +90,9 @@ def get_penalty_team(
     # But the infractor could also be a pfr_code, so we try that
     elif infractor in pfr_codes:
         team_code = pfr_codes_to_code[infractor]
-        if infractor == home_team:
+        if team_code == home_team:
             return "home"
-        elif infractor == away_team:
+        elif team_code == away_team:
             return "away"
     # We've failed to locate the player or team, another method will have to be
     # used
@@ -118,7 +118,10 @@ def get_penalty_player(penalty_string, home_team, away_team):
         The name, or "team" if it is a team penalty.
     """
     infractor = penalty_string.split("Penalty on")[1].split(":")[0].strip()
+
     if infractor == home_team or infractor == away_team:
+        return "team"
+    elif infractor in pfr_codes:
         return "team"
     else:
         return infractor

--- a/code/tests/play_by_play/test_penalty.py
+++ b/code/tests/play_by_play/test_penalty.py
@@ -17,7 +17,8 @@ class TestPlayByPlay(unittest.TestCase):
             "Luke Skywalker shot on Deathstar no good. Penalty on Darth Vader: Illegal Formation (Declined)",
             "Operation Overlord beginning. Penalty on The Allies : Offensive Beach Storming, 100 yards (no play)",
             "Short in the LHC causes explosion! Penalty on Superconducting Interconnects : Illegal Contact, 137 yards",
-            "I am not a penalty!"
+            "I am not a penalty!",
+            "United Airlines circles around, ordered by tower . Penalty on SFO : Illegal Fog, 1000 yards",
         )
         # The result of running split_penalties on the penalties; also the
         # input for further test functions
@@ -31,7 +32,8 @@ class TestPlayByPlay(unittest.TestCase):
             ["Penalty on Darth Vader: Illegal Formation (Declined)"],
             ["Penalty on The Allies : Offensive Beach Storming, 100 yards (no play)"],
             ["Penalty on Superconducting Interconnects : Illegal Contact, 137 yards"],
-            []
+            [],
+            ["Penalty on SFO : Illegal Fog, 1000 yards"],
         )
 
     def test_split_penalties(self):
@@ -65,6 +67,10 @@ class TestPlayByPlay(unittest.TestCase):
                 split_penalties(self.penalties[6]),
                 self.penalty_splits[6]
                 )
+        self.assertEqual(
+                split_penalties(self.penalties[7]),
+                self.penalty_splits[7]
+                )
 
     def test_get_penalty_team(self):
         self.__set_penalty_consts()
@@ -96,6 +102,10 @@ class TestPlayByPlay(unittest.TestCase):
         self.assertEqual(
                 get_penalty_team(self.penalty_splits[5][0], "home", '', '', '', ''),
                 "away"
+                )
+        self.assertEqual(
+                get_penalty_team(self.penalty_splits[7][0], '', 'SF', '', '', ''),
+                "home"
                 )
 
     def test_get_penalty_player(self):
@@ -129,6 +139,10 @@ class TestPlayByPlay(unittest.TestCase):
                 get_penalty_player(self.penalty_splits[5][0], '', ''),
                 "Superconducting Interconnects"
                 )
+        self.assertEqual(
+                get_penalty_player(self.penalty_splits[7][0], '', ''),
+                "team"
+                )
 
     def test_get_penalty_yards(self):
         self.__set_penalty_consts()
@@ -161,6 +175,10 @@ class TestPlayByPlay(unittest.TestCase):
                 get_penalty_yards(self.penalty_splits[5][0]),
                 137
                 )
+        self.assertEqual(
+                get_penalty_yards(self.penalty_splits[7][0]),
+                1000
+                )
         # Failure
         self.assertRaises(ValueError, get_penalty_yards, "Ten yards")
 
@@ -174,6 +192,7 @@ class TestPlayByPlay(unittest.TestCase):
         self.assertEqual(get_penalty_type(self.penalty_splits[3][0]), "declined")
         self.assertEqual(get_penalty_type(self.penalty_splits[4][0]), "no play")
         self.assertEqual(get_penalty_type(self.penalty_splits[5][0]), "accepted")
+        self.assertEqual(get_penalty_type(self.penalty_splits[7][0]), "accepted")
 
     def test_get_penalty_name(self):
         self.__set_penalty_consts()
@@ -201,6 +220,9 @@ class TestPlayByPlay(unittest.TestCase):
                 )
         self.assertEqual(get_penalty_name(self.penalty_splits[5][0]),
                 "Illegal Contact"
+                )
+        self.assertEqual(get_penalty_name(self.penalty_splits[7][0]),
+                "Illegal Fog"
                 )
 
 


### PR DESCRIPTION
The test `infractor == team` would always fail as the `infractor` is a
PFR code, and the `team` is our team code.

Added a unit test to cover this case as well.

This resolves Ten-Point-Touchdowns/Football-Data-Converter#11