### PR TITLE
Fix penalty assignment when offense is set wrong

### DIFF
--- a/code/raw_data_parsers/play_by_play/penalty.py
+++ b/code/raw_data_parsers/play_by_play/penalty.py
@@ -67,16 +67,18 @@ def get_penalty_team(
         "home" or "away"
     """
     penalty_name = get_penalty_name(penalty_string).lower()
-    # First we try to assign the team based on offense or defense penalties
-    if "offensive" in penalty_string.lower() \
-    or penalty_name in offense_penalties:
-        return off_team
-    elif "defensive" in penalty_string.lower() \
-    or penalty_name in defense_penalties:
-        if off_team == "home":
-            return "away"
-        else:
-            return "home"
+    # First we try to assign the team based on offense or defense penalties,
+    # but only if we have correctly identified the team on offense
+    if off_team:
+        if "offensive" in penalty_string.lower() \
+        or penalty_name in offense_penalties:
+            return off_team
+        elif "defensive" in penalty_string.lower() \
+        or penalty_name in defense_penalties:
+            if off_team == "home":
+                return "away"
+            else:
+                return "home"
     # Otherwise we need to use the player to assign the team
     infractor = penalty_string.split("Penalty on")[1].split(":")[0].strip()
     # WARNING


### PR DESCRIPTION
If a penalty can only be committed by the offense/defense, then that
team is automatically assigned. This was the case even if the team on
offense was unknown (for example due to
Ten-Point-Touchdowns/Football-Data-Converter#12). Now, if the team is
unknown, other methods are tried first to determine the correct team.